### PR TITLE
added two file types to be excluded from git push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 .vscode
 src/runjava.bat
+Chatrooms
+Files

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.class
 .DS_Store
+.vscode
+src/runjava.bat


### PR DESCRIPTION
So it doesn't show chat history and user-uploaded files in the github when we push any new update(s). Same goes for .vscode folder because I'm using VS Code to allow me to run java using JavaFX environment since jGRASP is extremely unreliable when it come with compiling. (Still getting "symbol not found" error with Status and ResponseType)